### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf -y install libicu && \
     dnf clean all
 USER 1001
 
-COPY --from=builder /opt/app-root/src/bin/addon-adapter /usr/local/bin/addon-adapter
+COPY --from=addon-adapter-builder /opt/app-root/src/bin/addon-adapter /usr/local/bin/addon-adapter
 
 ENTRYPOINT ["/usr/local/bin/addon-adapter"]
 


### PR DESCRIPTION
The name of the image from which the addon-adapter binary is copied
should be `addon-adapter-builder` and not `builder`. This breaks the
container buidl. This change fixes it.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>